### PR TITLE
Raxml module did not pass test and -w option only worked with cwd

### DIFF
--- a/lib/Bio/Tools/Run/Phylo/Raxml.pm
+++ b/lib/Bio/Tools/Run/Phylo/Raxml.pm
@@ -260,7 +260,7 @@ sub _run {
     my $outfile = 'RAxML_bestTree.' . $self->outfile_name;
     $outfile = File::Spec->catfile( ($self->w), $outfile ) if $self->w;
 
-    if ( ! -e $outfile || -z $outfile ) {
+    if ( !-e $outfile || -z $outfile ) {
         $self->warn("Raxml call had status of $status: $? [command $command] \n");
         return undef;
     }
@@ -400,7 +400,7 @@ sub _setparams {
     $param_string .= "-s $infile -n " . $self->outfile_name;
 
     my $null = ($^O =~ m/mswin/i) ? 'NUL' : '/dev/null';
-    	$param_string .= " > $null 2> $null"
+    $param_string .= " > $null 2> $null"
       if ( $self->quiet() || $self->verbose < 0 );
 
     $param_string;

--- a/lib/Bio/Tools/Run/Phylo/Raxml.pm
+++ b/lib/Bio/Tools/Run/Phylo/Raxml.pm
@@ -75,6 +75,7 @@ package Bio::Tools::Run::Phylo::Raxml;
 
 use strict;
 use File::Basename qw(basename);
+use File::Spec qw(catfile);
 use Bio::Seq;
 use Bio::SeqIO;
 use Bio::TreeIO;
@@ -231,7 +232,7 @@ sub run {
     elsif (! -e $in) {
         $self->throw("When not supplying a Bio::Align::AlignI object, you must supply a readable filename");
     }
-    
+
     $self->_run($in); 
 }
 
@@ -254,12 +255,13 @@ sub _run {
     $self->debug("Raxml command = $command");
 
     my $status  = system($command);
-
+	
     # raxml creates tree files with names like "RAxML_bestTree.ABDBxjjdfg3"
     my $outfile = 'RAxML_bestTree.' . $self->outfile_name;
+    $outfile = File::Spec->catfile( ($self->w), $outfile ) if $self->w;
 
-    if ( !-e $outfile || -z $outfile ) {
-        $self->warn("Raxml call had status of $status: $? [command $command]\n");
+    if ( ! -e $outfile || -z $outfile ) {
+        $self->warn("Raxml call had status of $status: $? [command $command] \n");
         return undef;
     }
 
@@ -398,7 +400,7 @@ sub _setparams {
     $param_string .= "-s $infile -n " . $self->outfile_name;
 
     my $null = ($^O =~ m/mswin/i) ? 'NUL' : '/dev/null';
-    $param_string .= " &> $null"
+    	$param_string .= " > $null 2> $null"
       if ( $self->quiet() || $self->verbose < 0 );
 
     $param_string;

--- a/t/Raxml.t
+++ b/t/Raxml.t
@@ -8,7 +8,7 @@ use strict;
 BEGIN {
     use Bio::Root::Test;
     test_begin(
-        -tests => 9,
+        -tests => 11,
     );
     use_ok('Bio::Root::IO');
     use_ok('Bio::Tools::Run::Phylo::Raxml');
@@ -17,19 +17,26 @@ BEGIN {
 
 END { unlink glob "RAxML_*.*"; }
 
-ok(my $raxml = Bio::Tools::Run::Phylo::Raxml->new(-p => 100, -quiet => 1), "Make the object");
+ok(my $raxml = Bio::Tools::Run::Phylo::Raxml->new(-p => 100, -quiet => 1, -d => 1), "Make the object");
 isa_ok( $raxml, 'Bio::Tools::Run::Phylo::Raxml');
 
 SKIP: {
     test_skip(
         -requires_executable => $raxml,
-        -tests               => 4
+        -tests               => 6
     );
 
     # The input could be an alignment file in phylip format
     my $alignfile = test_input_file("testaln.phylip");
     my $tree = $raxml->run($alignfile);
     ok( defined($tree), "Tree is defined" );
+
+	# The working directory could be different, i.e. -w set
+	$raxml->w($raxml->tempdir);
+	$tree = $raxml->run($alignfile);
+    ok( defined($tree), "Tree is defined" );
+	my $out = $raxml->w . '/RAxML_bestTree.' . $raxml->outfile_name;
+	ok( -e $out, "File containing best tree exists in tempdir" );
 
     # The input could be a SimpleAlign object
     my $alignio = Bio::AlignIO->new(
@@ -38,7 +45,7 @@ SKIP: {
     );
     my $alnobj = $alignio->next_aln;
 
-    $raxml = Bio::Tools::Run::Phylo::Raxml->new(-p => 100, -quiet => 1);
+    $raxml = Bio::Tools::Run::Phylo::Raxml->new(-p => 100, -quiet => 1, -d => 1);
     $tree = $raxml->run($alnobj);
     ok( defined($tree), "Tree is defined" );
     my @nodes = $tree->get_nodes;


### PR DESCRIPTION
(1) Test for Raxml wrapper does not pass, as Raxml complains about a starting tree and gives an assertion (tested on linux and mac). This was fixed by starting from a random tree (-d option in Raxml).
(2) Cannot use -w option, since the wrapper throws an error if the Raxml output file is not in the current working directory. This was fixed and a test was added to check if custom working directories (such as /tmp/) work.
(3) Redirect for -quiet option made Raxml write to the wrong file (for some reason). Redirecting was changed. 

I would be very happy if these changes could be incorporated,

Best Regards

Hannes Hettling