### PR TITLE
Making Raxml test run

### DIFF
--- a/lib/Bio/Tools/Run/Phylo/Raxml.pm
+++ b/lib/Bio/Tools/Run/Phylo/Raxml.pm
@@ -381,7 +381,7 @@ sub _setparams {
         my ( $tfh, $outfile ) = $self->io->tempfile( -dir => $dir );
         close($tfh);
         undef $tfh;
-        $outfile = File::Spec->basename($outfile);
+        $outfile = basename($outfile);
         $self->outfile_name($outfile);
     }
 


### PR DESCRIPTION
Raxml.pm test failed with `Can't locate object method "basename" via package "File::Spec"`, this is now fixed.