### PR TITLE
adjust version regex with optional space for BlastPlus

### DIFF
--- a/lib/Bio/Tools/Run/BlastPlus.pm
+++ b/lib/Bio/Tools/Run/BlastPlus.pm
@@ -152,7 +152,7 @@ sub _version {
 			die ("There was a problem running $exe : $!");
 	};
 	
-    if ($out =~ /blastdbcmd\:\s+(\S+)\nPackage\:\s+([^,]+)/xms) {
+    if ($out =~ /blastdbcmd\:\s+(\S+)\n\s*Package\:\s+([^,]+)/xms) {
         @{$self}{qw(program_version package_version)} = ($1, $2);
     } else {
         $self->throw("Unknown version output: $out");


### PR DESCRIPTION
the space before Package (output on OS X):

blastdbcmd: 2.7.1+
 Package: blast 2.7.1, build Oct 18 2017 20:40:57

causing SABlastPlus.t to fail.

perl -I lib t/SABlastPlus.t   

now passes